### PR TITLE
Barnard test doc: use c_1 and c_2 in complexity.

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -794,7 +794,7 @@ def barnard_exact(table, alternative="two-sided", pooled=True, n=32):
     The returned p-value is the maximum p-value taken over the nuisance
     parameter :math:`\pi`, where :math:`0 \leq \pi \leq 1`.
 
-    This function's complexity is O(n * total_c1 * total_c2), where `n` is the
+    This function's complexity is :math:`O(n c_1 c_2)`, where `n` is the
     number of sample points.
 
     References


### PR DESCRIPTION
total_c1 and total_c2 are not defined.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->